### PR TITLE
Restrict ingress traffic to port 10443

### DIFF
--- a/charts/clamav/Chart.yaml
+++ b/charts/clamav/Chart.yaml
@@ -14,8 +14,8 @@ type: application
 
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 0.2.6
+version: 0.2.7
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.
-appVersion: 0.2.6
+appVersion: 0.2.7

--- a/charts/clamav/templates/clamav-networkpolicy.yaml
+++ b/charts/clamav/templates/clamav-networkpolicy.yaml
@@ -10,4 +10,4 @@ spec:
   - ports:
     - protocol: TCP
       port: 10443
-  - from: {{ toYaml .Values.service.ingress | nindent 4 }}
+    from: {{ toYaml .Values.service.ingress | nindent 4 }}


### PR DESCRIPTION
At the moment the network policy allows access to all ports as the ports and from sections are counted as 2 separate rules