### PR TITLE
missing start.sh from deployment command

### DIFF
--- a/charts/clamav/Chart.yaml
+++ b/charts/clamav/Chart.yaml
@@ -14,8 +14,8 @@ type: application
 
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 0.3.0
+version: 0.3.1
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.
-appVersion: 0.3.0
+appVersion: 0.3.1

--- a/charts/clamav/templates/clamav-deployment.yaml
+++ b/charts/clamav/templates/clamav-deployment.yaml
@@ -19,7 +19,7 @@ spec:
       containers:
       - name: clamav
         image: "{{ .Values.clamav.image }}:{{ default .Chart.AppVersion .Values.clamav.version }}"
-        command: ['clamd']
+        command: ['./start.sh']
         ports:
         - containerPort: 3310
           name: api


### PR DESCRIPTION
Fixes issue with long running scanning pods, they would not get updated definitions, start.sh is now called in the deployment to resolve this.