### PR TITLE
Fix issue with freshclam in scanning pods

### DIFF
--- a/charts/clamav/README.md
+++ b/charts/clamav/README.md
@@ -2,7 +2,7 @@ clamav
 ======
 A Helm chart for deploying a clamav-http service on kubernetes
 
-Current chart version is `0.3.0`
+Current chart version is `0.3.1`
 
 ## Chart Values
 

--- a/charts/clamav/templates/clamav-configmap.yaml
+++ b/charts/clamav/templates/clamav-configmap.yaml
@@ -38,10 +38,9 @@ data:
   freshclam.conf: |
     LogTime yes
     LogVerbose yes
+    NotifyClamd /etc/clamav/clamd.conf
     LogSyslog no
     DatabaseOwner clam
-    DatabaseMirror http://{{ include "clamav.fullname" . }}-mirror
-    Foreground yes
     # This option allows you to easily point freshclam to private mirrors.
     # If PrivateMirror is set, freshclam does not attempt to use DNS
     # to determine whether its databases are out-of-date, instead it will
@@ -52,5 +51,4 @@ data:
     # and ScriptedUpdates. It can be used multiple times to provide
     # fall-back mirrors.
     # Default: disabled
-    #PrivateMirror mirror1.example.com
-    #PrivateMirror mirror2.example.com
+    PrivateMirror http://{{ include "clamav.fullname" . }}-mirror

--- a/charts/clamav/templates/clamav-configmap.yaml
+++ b/charts/clamav/templates/clamav-configmap.yaml
@@ -39,6 +39,7 @@ data:
     LogTime yes
     LogVerbose yes
     NotifyClamd /etc/clamav/clamd.conf
+    Checks 24
     LogSyslog no
     DatabaseOwner clam
     # This option allows you to easily point freshclam to private mirrors.

--- a/charts/clamav/templates/clamav-deployment.yaml
+++ b/charts/clamav/templates/clamav-deployment.yaml
@@ -20,7 +20,9 @@ spec:
       containers:
       - name: clamav
         image: "{{ .Values.clamav.image }}:{{ default .Chart.AppVersion .Values.clamav.version }}"
-        command: ['./start.sh']
+        command: ["/bin/bash", "-c"]
+        args:
+          - freshclam -d --stdout --foreground=true >> /proc/1/fd/1 & clamd
         ports:
         - containerPort: 3310
           name: api

--- a/charts/clamav/templates/clamav-deployment.yaml
+++ b/charts/clamav/templates/clamav-deployment.yaml
@@ -15,6 +15,7 @@ spec:
       labels:
         name: {{ include "clamav.fullname" . }}
       annotations:
+        checksum/config: {{ include (print $.Template.BasePath "/clamav-configmap.yaml") . | sha256sum }}
     spec:
       containers:
       - name: clamav

--- a/charts/clamav/templates/clamav-mirror-configmap.yaml
+++ b/charts/clamav/templates/clamav-mirror-configmap.yaml
@@ -11,7 +11,7 @@ data:
 
   freshclam.conf: |    
     DatabaseOwner clam
-    DatabaseMirror http://localhost:8081
+    PrivateMirror http://localhost:8081
     TestDatabases yes
     LogVerbose yes
 

--- a/clamav/Dockerfile
+++ b/clamav/Dockerfile
@@ -7,8 +7,6 @@ WORKDIR /clam
 RUN apk add --update-cache bash wget curl shadow \
     clamav=$CLAM_VERSION clamav-libunrar=$CLAM_VERSION
 
-COPY start.sh .
-
 RUN adduser -S -g clamav -u 1000 clam \
     && chown -R clam:clamav /clam /var/log/clamav
 

--- a/clamav/start.sh
+++ b/clamav/start.sh
@@ -1,4 +1,0 @@
-#!/bin/bash
-
-freshclam -d &
-clamd


### PR DESCRIPTION
- Sends freshclam logs to stdout of pid 1
- Changes from DatabaseMirror to PrivateMirror in freshclam.conf, this disables the DNS check for signature definitions on the client pods, we don't want this as the mirror could conceivably behind the published DNS record, they go direct to the private mirror to check for updates.