### PR TITLE
clamav-mirror - accesslogs

### DIFF
--- a/charts/clamav/templates/clamav-mirror-configmap.yaml
+++ b/charts/clamav/templates/clamav-mirror-configmap.yaml
@@ -22,6 +22,8 @@ data:
       ".htm" => "text/html", 
     )
     index-file.names = ( "index.htm" )
+    server.modules += ( "mod_accesslog" )
+    accesslog.filename  = "/dev/stderr" 
 
   lightttpdmirror.conf: |
     server.document-root = "/home/clam/mirror/"
@@ -30,4 +32,6 @@ data:
       ".htm" => "text/html", 
     )
     index-file.names = ( "index.htm" )
+    server.modules += ( "mod_accesslog" )
+    accesslog.filename  = "/dev/stderr" 
     

--- a/clamav-mirror/lighttpdhost.conf
+++ b/clamav-mirror/lighttpdhost.conf
@@ -7,3 +7,7 @@ mimetype.assign = (
 )
 
 index-file.names = ( "index.htm" )
+
+server.modules += ( "mod_accesslog" )
+
+accesslog.filename  = "/dev/stderr"

--- a/clamav-mirror/lighttpdmirror.conf
+++ b/clamav-mirror/lighttpdmirror.conf
@@ -7,3 +7,7 @@ mimetype.assign = (
 )
 
 index-file.names = ( "index.htm" )
+
+server.modules += ( "mod_accesslog" )
+
+accesslog.filename  = "/dev/stderr" 


### PR DESCRIPTION
the clamav-mirror container has two lighthttpd processes which didn't have access logs enabled making it hard to debug issues.