### PR TITLE
ClamAV test mirror

### DIFF
--- a/test/clamav_config/freshclam.conf
+++ b/test/clamav_config/freshclam.conf
@@ -1,0 +1,17 @@
+LogTime yes
+LogVerbose yes
+NotifyClamd /etc/clamav/clamd.conf
+Checks 24
+LogSyslog no
+DatabaseOwner clam
+# This option allows you to easily point freshclam to private mirrors.
+# If PrivateMirror is set, freshclam does not attempt to use DNS
+# to determine whether its databases are out-of-date, instead it will
+# use the If-Modified-Since request or directly check the headers of the
+# remote database files. For each database, freshclam first attempts
+# to download the CLD file. If that fails, it tries to download the
+# CVD file. This option overrides DatabaseMirror, DNSDatabaseInfo
+# and ScriptedUpdates. It can be used multiple times to provide
+# fall-back mirrors.
+# Default: disabled
+PrivateMirror http://clamav-mirror:8080

--- a/test/docker-compose.yml
+++ b/test/docker-compose.yml
@@ -10,5 +10,12 @@ services:
     command: ["/bin/sh", "-c", "freshclam --no-warnings && echo 'TCPSocket 3310' | clamd -c /dev/stdin --foreground"]
     tmpfs:                                                                                                                                                                                                     
     - /var/lib/clamav:uid=1000
+    volumes:
+    - type: bind
+      source: ./clamav_config/
+      target: /etc/clamav/
+    depends_on:
+    - clamav-mirror
+    restart: unless-stopped
   clamav-mirror:
     build: ../clamav-mirror


### PR DESCRIPTION
In the testing script the clamav container wasn't configured to use the clamav-mirror container as a mirror to download the signature database. This adds that functionality.