### PR TITLE
ACP-25646 Bump nginx-proxy version; re-peg deps

### DIFF
--- a/charts/clamav/Chart.yaml
+++ b/charts/clamav/Chart.yaml
@@ -14,8 +14,8 @@ type: application
 
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 0.5.4
+version: 0.5.5
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.
-appVersion: 0.5.4
+appVersion: 0.5.5

--- a/charts/clamav/values.yaml
+++ b/charts/clamav/values.yaml
@@ -106,7 +106,7 @@ nginxProxy:
   # nginxProxy.image -- The nginx proxy docker image
   image: quay.io/ukhomeofficedigital/acp-nginx-proxy-rocky
   # nginxProxy.version -- The nginx proxy docker image version
-  version: 0.0.7@sha256:c28cbbd20e4867774208df015926a8cce9c795377dedc65023fd7b4ecab99110
+  version: 0.0.8@sha256:4255c7f048e4f8542a3ea81fa91e4a642b5048b9ee0585229829561a29b71471
   # nginxProxy.resources -- The resource requests and limits for the nginx proxy service
   resources:
     requests:

--- a/clamav-http/Dockerfile
+++ b/clamav-http/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.26.3-alpine3.23 AS builder
+FROM golang:1.26.4-alpine3.23 AS builder
 
 WORKDIR /go/src/github.com/ukhomeoffice/clamav-http/clamav-http
 
@@ -9,7 +9,7 @@ COPY server/  ./server/
 RUN CGO_ENABLED=0 GOOS=linux go install -v \
             github.com/ukhomeoffice/clamav-http/clamav-http
 
-FROM alpine:3.23.4
+FROM alpine:3.23
 
 RUN apk update && apk upgrade --no-cache && \
     apk --no-cache add ca-certificates

--- a/clamav-mirror/Dockerfile
+++ b/clamav-mirror/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.26.3-alpine3.23 AS supercronic-build
+FROM golang:1.26.4-alpine3.23 AS supercronic-build
 RUN go install github.com/aptible/supercronic@v0.2.45
 
 FROM python:3.14-alpine3.23

--- a/clamav-mirror/Dockerfile
+++ b/clamav-mirror/Dockerfile
@@ -1,5 +1,5 @@
 FROM golang:1.26.4-alpine3.23 AS supercronic-build
-RUN go install github.com/aptible/supercronic@v0.2.45
+RUN go install github.com/aptible/supercronic@v0.2.46
 
 FROM python:3.14-alpine3.23
 


### PR DESCRIPTION
The nginx-proxy we're using had some vulnerabilities. This updates that.
While we're here, we also bump the dependencies of the Docker images.

I dropped the minor version in `FROM alpine` as I don't think we care about that amount of precision; these images are updated infrequently.