### PR TITLE
ACPENG-2944: Scheduled ClamAV/Alpine version checker that files Jira tickets

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -194,8 +194,8 @@ steps:
       cpu: 500
       memory: 512Mi
   environment:
-    JIRA_TOKEN:
-      from_secret: jira_token
+    JIRA_API_TOKEN:
+      from_secret: JIRA_API_TOKEN
     GITLAB_TOKEN:
       from_secret: gitlab_token
   commands:

--- a/.drone.yml
+++ b/.drone.yml
@@ -199,20 +199,18 @@ platform:
   os: linux
   arch: amd64
 
-# Runs only on a scheduled Drone cron (create the cron in Drone, targeting
-# master). Raises Jira tickets when ClamAV/Alpine need attention (ACPENG-2944).
+# Raises Jira tickets when ClamAV/Alpine need attention (ACPENG-2944).
 #
-# TEMPORARY - REVERT BEFORE MERGE. The push trigger and branch filter below let
-# this pipeline run from the feature branch, so we can prove the drone-gh pods
-# can reach internal GitLab before merging. A cron build checks out master's
-# .drone.yml, so that is otherwise untestable until it is too late to fix.
-# On revert, restore to:  event: [cron, custom]
+# cron   - the schedule itself, registered in Drone against master.
+# custom - lets anyone run the check on demand from the Drone UI or
+#          `drone build create`, without waiting for the next scheduled firing.
+#
+# Deliberately not push/pull_request: the answer changes when Alpine or ClamAV
+# publish something, not when someone commits to this repo.
 trigger:
   event:
   - cron
-  - push
-  branch:
-  - ACPENG-2944
+  - custom
 
 steps:
 - name: clamav-version-check
@@ -235,12 +233,6 @@ steps:
   - python -m venv /tmp/venv
   - . /tmp/venv/bin/activate
   - pip install --no-cache-dir -r requirements.txt
-  # TEMPORARY - REMOVE BEFORE MERGE. Jira answered the JQL as an anonymous user,
-  # so the PAT is being sent but not accepted. This probe reports the token's
-  # length (not its value) and who Jira thinks we are. 200 = the PAT works and
-  # the account it names needs Browse rights on ACPENG; 401 = the PAT itself is
-  # rejected, so it is expired, revoked, or not a Data Center PAT.
-  - python -c "import os,requests;t=os.environ['JIRA_API_TOKEN'];print('token chars:',len(t),'| after strip:',len(t.strip()));r=requests.get('https://collaboration.homeoffice.gov.uk/jira/rest/api/2/myself',headers={'Authorization':'Bearer '+t.strip()},timeout=20);print('GET /myself ->',r.status_code);print(r.text[:300])"
   - python version_checker.py
 
 ...

--- a/.drone.yml
+++ b/.drone.yml
@@ -7,6 +7,12 @@ platform:
   os: linux
   arch: amd64
 
+# Builds/scans run on push/PR/tag - never on the version-check cron below.
+trigger:
+  event:
+    exclude:
+    - cron
+
 steps:
 - name: test_api
   pull: always
@@ -163,5 +169,43 @@ steps:
 services:
 - name: docker
   image: 340268328991.dkr.ecr.eu-west-2.amazonaws.com/acp/dind
+
+---
+kind: pipeline
+type: kubernetes
+name: version-check
+
+platform:
+  os: linux
+  arch: amd64
+
+# Runs only on a scheduled Drone cron (create the cron in Drone, targeting
+# master). Raises Jira tickets when ClamAV/Alpine need attention (ACPENG-2944).
+trigger:
+  event:
+  - cron
+
+steps:
+- name: clamav-version-check
+  pull: if-not-exists
+  image: 340268328991.dkr.ecr.eu-west-2.amazonaws.com/acp/acp/python-trivy:v1.0.0
+  resources:
+    limits:
+      cpu: 500
+      memory: 512Mi
+  environment:
+    JIRA_TOKEN:
+      from_secret: jira_token
+    GITLAB_TOKEN:
+      from_secret: gitlab_token
+  commands:
+  - cd version-checker
+  # Install into a venv so a PEP 668 "externally-managed-environment" base image
+  # can't refuse the install. Drone runs these commands as one shell script, so
+  # the activate persists to the pip/python lines below.
+  - python -m venv /tmp/venv
+  - . /tmp/venv/bin/activate
+  - pip install --no-cache-dir -r requirements.txt
+  - python version_checker.py
 
 ...

--- a/.drone.yml
+++ b/.drone.yml
@@ -14,6 +14,26 @@ trigger:
     - cron
 
 steps:
+- name: test-version-checker
+  pull: if-not-exists
+  image: 340268328991.dkr.ecr.eu-west-2.amazonaws.com/acp/acp/python-trivy:v1.0.0
+  resources:
+    limits:
+      cpu: 500
+      memory: 512Mi
+  commands:
+  - cd version-checker
+  # Same venv as the version-check cron below: a PEP 668 "externally-managed-
+  # environment" base image refuses a bare pip install.
+  - python -m venv /tmp/venv
+  - . /tmp/venv/bin/activate
+  - pip install --no-cache-dir -r requirements-dev.txt
+  - python -m pytest tests/ -q
+  when:
+    event:
+    - push
+    - pull_request
+
 - name: test_api
   pull: always
   image: docker/compose:alpine-1.29.2

--- a/.drone.yml
+++ b/.drone.yml
@@ -235,6 +235,12 @@ steps:
   - python -m venv /tmp/venv
   - . /tmp/venv/bin/activate
   - pip install --no-cache-dir -r requirements.txt
+  # TEMPORARY - REMOVE BEFORE MERGE. Jira answered the JQL as an anonymous user,
+  # so the PAT is being sent but not accepted. This probe reports the token's
+  # length (not its value) and who Jira thinks we are. 200 = the PAT works and
+  # the account it names needs Browse rights on ACPENG; 401 = the PAT itself is
+  # rejected, so it is expired, revoked, or not a Data Center PAT.
+  - python -c "import os,requests;t=os.environ['JIRA_API_TOKEN'];print('token chars:',len(t),'| after strip:',len(t.strip()));r=requests.get('https://collaboration.homeoffice.gov.uk/jira/rest/api/2/myself',headers={'Authorization':'Bearer '+t.strip()},timeout=20);print('GET /myself ->',r.status_code);print(r.text[:300])"
   - python version_checker.py
 
 ...

--- a/.drone.yml
+++ b/.drone.yml
@@ -235,8 +235,6 @@ steps:
   - python -m venv /tmp/venv
   - . /tmp/venv/bin/activate
   - pip install --no-cache-dir -r requirements.txt
-  # TEMPORARY - REVERT BEFORE MERGE. --dry-run proves the GitLab fetch, tag
-  # resolution and rules without filing a Jira ticket from a feature branch.
-  - python version_checker.py --dry-run
+  - python version_checker.py
 
 ...

--- a/.drone.yml
+++ b/.drone.yml
@@ -201,9 +201,18 @@ platform:
 
 # Runs only on a scheduled Drone cron (create the cron in Drone, targeting
 # master). Raises Jira tickets when ClamAV/Alpine need attention (ACPENG-2944).
+#
+# TEMPORARY - REVERT BEFORE MERGE. The push trigger and branch filter below let
+# this pipeline run from the feature branch, so we can prove the drone-gh pods
+# can reach internal GitLab before merging. A cron build checks out master's
+# .drone.yml, so that is otherwise untestable until it is too late to fix.
+# On revert, restore to:  event: [cron, custom]
 trigger:
   event:
   - cron
+  - push
+  branch:
+  - ACPENG-2944
 
 steps:
 - name: clamav-version-check
@@ -226,6 +235,8 @@ steps:
   - python -m venv /tmp/venv
   - . /tmp/venv/bin/activate
   - pip install --no-cache-dir -r requirements.txt
-  - python version_checker.py
+  # TEMPORARY - REVERT BEFORE MERGE. --dry-run proves the GitLab fetch, tag
+  # resolution and rules without filing a Jira ticket from a feature branch.
+  - python version_checker.py --dry-run
 
 ...

--- a/clamav-http/Dockerfile
+++ b/clamav-http/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.26.4-alpine3.23 AS builder
+FROM golang:1.26.5-alpine3.23 AS builder
 
 WORKDIR /go/src/github.com/ukhomeoffice/clamav-http/clamav-http
 

--- a/clamav-mirror/Dockerfile
+++ b/clamav-mirror/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.26.4-alpine3.23 AS supercronic-build
+FROM golang:1.26.5-alpine3.23 AS supercronic-build
 RUN go install github.com/aptible/supercronic@v0.2.46
 
 FROM python:3.14-alpine3.23

--- a/version-checker/.gitignore
+++ b/version-checker/.gitignore
@@ -1,0 +1,3 @@
+__pycache__/
+*.pyc
+.pytest_cache/

--- a/version-checker/requirements-dev.txt
+++ b/version-checker/requirements-dev.txt
@@ -1,0 +1,2 @@
+-r requirements.txt
+pytest==9.1.1

--- a/version-checker/requirements.txt
+++ b/version-checker/requirements.txt
@@ -1,1 +1,3 @@
 atlassian-python-api==3.41.16
+requests==2.31.0
+PyYAML==6.0.2

--- a/version-checker/requirements.txt
+++ b/version-checker/requirements.txt
@@ -1,0 +1,1 @@
+atlassian-python-api==3.41.16

--- a/version-checker/requirements.txt
+++ b/version-checker/requirements.txt
@@ -1,3 +1,7 @@
 atlassian-python-api==3.41.16
-requests==2.31.0
+# Matches the python-trivy image's preinstalled /opt/pydeps. Pinning below
+# 2.32.0 downgrades it and breaks the image's python-gitlab, which requires
+# >=2.32.0. 2.32.x also carries the fixes for the verify=False session leak
+# and the .netrc credential leak.
+requests==2.34.0
 PyYAML==6.0.2

--- a/version-checker/tests/test_version_checker.py
+++ b/version-checker/tests/test_version_checker.py
@@ -1,0 +1,179 @@
+"""Unit tests for the ClamAV version checker's pure logic (no network)."""
+import sys
+from datetime import date, timedelta
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+import version_checker as vc  # noqa: E402
+
+
+# --- version_key / normalize_tag -------------------------------------------
+def test_version_key_ordering():
+    assert vc.version_key("1.4.4-r0") < vc.version_key("1.4.4-r1")
+    assert vc.version_key("1.4.4-r1") < vc.version_key("1.4.5-r0")
+    assert vc.version_key("1.4.5-r0") < vc.version_key("1.5.3")
+    assert vc.version_key("3.23") < vc.version_key("3.24")
+    # Deploy tags: the leading "v" is ignored.
+    assert vc.version_key("v0.5.4") < vc.version_key("v0.5.5")
+    assert vc.version_key(None) == (0, 0, 0, 0)
+
+
+def test_normalize_tag():
+    assert vc.normalize_tag("v0.5.5") == "v0.5.5"
+    assert vc.normalize_tag("0.5.5") == "v0.5.5"
+    assert vc.normalize_tag(" v0.5.5 ") == "v0.5.5"
+
+
+# --- parse_dockerfile ------------------------------------------------------
+def test_parse_alpine_form():
+    d = vc.parse_dockerfile(
+        "FROM alpine:3.23.4\nENV CLAM_VERSION=1.4.4-r0\n",
+        "clamav/Dockerfile@v0.5.5",
+    )
+    assert d["clamav"] == "1.4.4-r0"
+    assert d["alpine"] == "3.23.4"
+    assert d["alpine_branch"] == "3.23"
+    assert d["path"] == "clamav/Dockerfile@v0.5.5"
+
+
+def test_parse_python_alpine_form():
+    text = (
+        "FROM golang:1.26.4-alpine3.23 AS supercronic-build\n"
+        "FROM python:3.14-alpine3.23\n"
+        "ENV CLAM_VERSION=1.4.4-r0\n"
+    )
+    d = vc.parse_dockerfile(text, "clamav-mirror/Dockerfile@v0.5.5")
+    assert d["alpine_branch"] == "3.23"
+    assert d["clamav"] == "1.4.4-r0"
+
+
+def test_parse_no_clam_version():
+    d = vc.parse_dockerfile("FROM alpine:3.23.4\n", "x")
+    assert d["clamav"] is None
+    assert d["alpine_branch"] == "3.23"
+
+
+# --- deployed_versions_from_values -----------------------------------------
+def _values_yaml(v: str) -> str:
+    return (
+        f"clamav:\n  version: {v}\n"
+        f"clamavHTTP:\n  version: {v}\n"
+        f"clamavMirror:\n  version: {v}\n"
+    )
+
+
+def test_deployed_all_same():
+    d = vc.deployed_versions_from_values(
+        {"prod": _values_yaml("v0.5.5"), "testing": _values_yaml("v0.5.5")}
+    )
+    assert d["reference_tag"] == "v0.5.5"
+    assert d["drift"] is False
+    assert set(d["per_env"]) == {"prod", "testing"}
+    assert d["per_env"]["prod"]["clamav"] == "v0.5.5"
+
+
+def test_deployed_divergent_picks_lowest_and_flags_drift():
+    d = vc.deployed_versions_from_values(
+        {"prod": _values_yaml("v0.5.4"), "testing": _values_yaml("v0.5.5")}
+    )
+    assert d["reference_tag"] == "v0.5.4"  # lowest = most behind
+    assert d["drift"] is True
+
+
+def test_deployed_none_found_raises():
+    with pytest.raises(SystemExit):
+        vc.deployed_versions_from_values({"prod": "unrelated:\n  key: value\n"})
+
+
+# --- evaluate --------------------------------------------------------------
+def _soon(days: int = 10) -> str:
+    return (date.today() + timedelta(days=days)).isoformat()
+
+
+_SHIPPED = {
+    "clamav": "1.4.4-r0",
+    "alpine_branch": "3.23",
+    "per_file": [{"path": "clamav/Dockerfile@v0.5.5"}],
+}
+
+
+def _rules(findings):
+    return {f["rule"] for f in findings}
+
+
+def test_r1_in_branch_bump_ticket():
+    findings = vc.evaluate(
+        _SHIPPED,
+        {"3.23": "1.4.5-r0"},
+        [{"cycle": "1.4", "latest": "1.4.5", "eol": False}],
+        [{"cycle": "3.23", "eol": False}],
+    )
+    assert "R1" in _rules(findings)
+    r1 = next(f for f in findings if f["rule"] == "R1")
+    assert r1["actionable"] and r1["priority"] == "Medium"
+    assert "R3" not in _rules(findings)
+
+
+def test_r2_base_bump_ticket():
+    findings = vc.evaluate(
+        _SHIPPED,
+        {"3.23": "1.4.4-r0", "3.24": "1.4.5-r0"},
+        [{"cycle": "1.4", "latest": "1.4.5", "eol": False}],
+        [{"cycle": "3.23", "eol": False}, {"cycle": "3.24", "eol": False}],
+    )
+    assert "R2" in _rules(findings)
+    assert "R1" not in _rules(findings)
+    r2 = next(f for f in findings if f["rule"] == "R2")
+    assert r2["actionable"] and r2["priority"] == "Low"
+
+
+def test_r4_clamav_eol_ticket():
+    findings = vc.evaluate(
+        _SHIPPED,
+        {"3.23": "1.4.4-r0"},
+        [{"cycle": "1.4", "latest": "1.4.4", "eol": _soon()}],
+        [{"cycle": "3.23", "eol": False}],
+    )
+    assert "R4" in _rules(findings)
+    r4 = next(f for f in findings if f["rule"] == "R4")
+    assert r4["actionable"] and r4["priority"] == "High"
+
+
+def test_r5_alpine_eol_ticket():
+    findings = vc.evaluate(
+        _SHIPPED,
+        {"3.23": "1.4.4-r0"},
+        [{"cycle": "1.4", "latest": "1.4.4", "eol": False}],
+        [{"cycle": "3.23", "eol": _soon()}],
+    )
+    assert "R5" in _rules(findings)
+    r5 = next(f for f in findings if f["rule"] == "R5")
+    assert r5["actionable"] and r5["priority"] == "High"
+
+
+def test_r3_upstream_ahead_signal_only():
+    shipped = {**_SHIPPED, "clamav": "1.4.5-r0"}  # at branch max, so R1 quiet
+    findings = vc.evaluate(
+        shipped,
+        {"3.23": "1.4.5-r0"},
+        [
+            {"cycle": "1.5", "latest": "1.5.3", "eol": False},
+            {"cycle": "1.4", "latest": "1.4.5", "eol": False},
+        ],
+        [{"cycle": "3.23", "eol": False}],
+    )
+    assert _rules(findings) == {"R3"}
+    r3 = next(f for f in findings if f["rule"] == "R3")
+    assert r3["actionable"] is False and r3["priority"] is None
+
+
+def test_all_quiet_no_findings():
+    findings = vc.evaluate(
+        _SHIPPED,
+        {"3.23": "1.4.4-r0"},
+        [{"cycle": "1.4", "latest": "1.4.4", "eol": False}],
+        [{"cycle": "3.23", "eol": False}],
+    )
+    assert findings == []

--- a/version-checker/version_checker.py
+++ b/version-checker/version_checker.py
@@ -1,207 +1,627 @@
 #!/usr/bin/env python3
 """
-Create Jira tickets for ACP ECR images with critical or high CVEs.
+ClamAV version checker (ACPENG-2944).
+
+Scheduled automation that reconciles the ClamAV version we *deploy* against what
+Alpine can actually package and what ClamAV releases upstream, then raises a
+Jira ticket when there is something a human can action.
+
+The "current" version is the version actually deployed, read from the private
+`clamav-deploy` GitLab repo's per-environment values files (`values/<env>.yaml`,
+keys `clamav.version` / `clamavHTTP.version` / `clamavMirror.version`). That
+value is a `clamav-http` git tag (e.g. "v0.5.5"); the checker resolves it to the
+ClamAV/Alpine pins by reading `clamav/Dockerfile` + `clamav-mirror/Dockerfile`
+from `clamav-http` *at that tag*. This reflects what is deployed, not the tip of
+master. When environments/components diverge, the checker reasons about the
+lowest (most-behind) version and flags the drift.
+
+Because ClamAV reaches our image *through* Alpine (`apk add clamav`), three
+version numbers have to be reconciled, not one:
+
+  1. Deployed         - the tag pinned in clamav-deploy -> its Dockerfile pins.
+  2. Alpine-reachable - the newest `clamav` package Alpine offers for our
+                        branch, newer stable branches, and edge (APKINDEX).
+  3. Upstream         - the newest ClamAV release + EOL dates (endoflife.date).
+
+Decision rules (see evaluate()):
+  R1  in-branch bump      -> ticket   (our branch has clamav > deployed)
+  R2  base bump           -> ticket   (a newer stable branch offers clamav we
+                                        can't reach in-branch)
+  R4  ClamAV near EOL     -> ticket   (deployed series' eol within WARN_DAYS)
+  R5  Alpine base near EOL-> ticket   (our Alpine branch eol within WARN_DAYS)
+  R3  upstream ahead      -> SIGNAL   (upstream > best Alpine-reachable). Logged
+                                        only - nothing is actionable until Alpine
+                                        packages it, at which point R1/R2 fire.
 
 Usage:
-    python3 scripts/create_vuln_tickets.py             # creates 1 ticket
-    python3 scripts/create_vuln_tickets.py --dry-run   # prints payload, no API call
-    python3 scripts/create_vuln_tickets.py --all       # creates all tickets
-    python3 scripts/create_vuln_tickets.py --image acp/dind  # specific base image
-    python3 scripts/create_vuln_tickets.py --auto      # CI mode: process all eligible
-                                                       # images, persist de-dup state
-    python3 scripts/create_vuln_tickets.py --auto --state-file s3://bucket/jira/created_tickets.json
+    python3 version_checker.py --dry-run     # print findings, no Jira calls
+    python3 version_checker.py               # create/refresh Jira tickets
 
 Requires:
-    export JIRA_TOKEN="your-PAT"
+    export GITLAB_TOKEN="read-only-PAT"      # always (reads clamav-deploy)
+    export JIRA_TOKEN="your-PAT"             # only when creating tickets
 """
 from __future__ import annotations
 
 import argparse
-import json
+import io
 import os
+import re
 import sys
-from collections import defaultdict
+import tarfile
+from datetime import date, datetime
 from pathlib import Path
-from urllib.parse import urlparse
+from urllib.parse import quote
 
-from atlassian import Jira
+import requests
+import yaml
 
+# --- Jira -------------------------------------------------------------------
 JIRA_URL = "https://collaboration.homeoffice.gov.uk/jira"
 JIRA_PROJECT = "ACPENG"
 JIRA_EPIC_FIELD = "customfield_10006"
+# ACP07: Cloud Security epic (https://collaboration.homeoffice.gov.uk/jira/browse/ACPENG-2598).
 JIRA_EPIC_KEY = "ACPENG-2598"
+# Stable label used to find/refresh our own tickets instead of duplicating.
+DEDUP_LABEL = "clamav-version-check"
+
+# --- Deployed version source (clamav-deploy, private GitLab) ----------------
+GITLAB_BASE = "https://gitlab.digital.homeoffice.gov.uk"
+GITLAB_API = f"{GITLAB_BASE}/api/v4"
+CLAMAV_DEPLOY_PROJECT = "acp/clamav-deploy"
+VALUES_PATH = "values"
+DEPLOY_REF = "master"
+# Keys in each values file that pin a clamav-http tag (e.g. "v0.5.5").
+VERSION_KEYS = ("clamav", "clamavHTTP", "clamavMirror")
+
+# --- Shipped pins (clamav-http Dockerfiles, resolved at the deployed tag) ---
+CLAMAV_HTTP_RAW = "https://raw.githubusercontent.com/UKHomeOffice/clamav-http"
+CLAMAV_DOCKERFILES = ("clamav/Dockerfile", "clamav-mirror/Dockerfile")
+
+# --- Data sources -----------------------------------------------------------
+CLAMAV_EOL_API = "https://endoflife.date/api/clamav.json"
+ALPINE_EOL_API = "https://endoflife.date/api/alpine-linux.json"
+ALPINE_CDN = "https://dl-cdn.alpinelinux.org/alpine"
+ALPINE_REPO = "community"
+ALPINE_ARCH = "x86_64"
+
+# How many days before an EOL date we start raising a ticket.
+WARN_DAYS = 90
+
+HTTP_TIMEOUT = 30
 
 
-WORKSPACE = Path(__file__).parent.parent / "workspace"
-
-
-def get_current_versions(dockerfile_path):
+# ---------------------------------------------------------------------------
+# Version helpers
+# ---------------------------------------------------------------------------
+def version_key(v: str | None) -> tuple[int, int, int, int]:
     """
-    Reads the Dockerfile to get the current versions
-    of Alpine and ClamAV
+    Turn a version string into a comparable tuple.
+
+    Handles Alpine package versions ("1.4.4-r0"), upstream ClamAV releases
+    ("1.5.3"), Alpine branches ("3.23" / "3.23.4") and deploy tags ("v0.5.5" -
+    the leading "v" is ignored). The `-rN` package release is kept as a
+    lowest-priority tiebreaker so "1.4.4-r1" > "1.4.4-r0".
     """
-    pass
+    if not v:
+        return (0, 0, 0, 0)
+    v = v.strip()
+    rel = 0
+    if "-r" in v:
+        base, _, tail = v.partition("-r")
+        rel = int(re.sub(r"\D", "", tail) or 0)
+    else:
+        base = v
+    nums = tuple(int(p) for p in re.findall(r"\d+", base)[:3])
+    nums += (0,) * (3 - len(nums))
+    return (*nums, rel)
 
 
-def retrieve_latest_clam_av_versions() -> list[str]:
+def series_of(clamav_version: str) -> str:
+    """Return the ClamAV release series (major.minor), e.g. "1.4.4-r0" -> "1.4"."""
+    nums = re.findall(r"\d+", clamav_version)
+    return ".".join(nums[:2]) if len(nums) >= 2 else clamav_version
+
+
+def days_until(eol) -> int | None:
     """
-    Calls https://api.github.com/repos/Cisco-Talos/clamav/releases?per_page=5
-    to get the latest 5 ClamAV releases 
+    Days from today until an endoflife.date `eol` field.
+
+    Returns None when the field is a boolean (cycle has no scheduled EOL) or is
+    unparseable. Negative means the date is already in the past.
     """
-    pass
+    if not isinstance(eol, str):
+        return None
+    try:
+        eol_date = datetime.strptime(eol, "%Y-%m-%d").date()
+    except ValueError:
+        return None
+    return (eol_date - date.today()).days
 
 
-def retrieve_latest_alpine_version():
+def normalize_tag(tag: str) -> str:
+    """Ensure a deploy version has a single leading "v" (values already do)."""
+    tag = tag.strip()
+    return tag if tag.startswith("v") else f"v{tag}"
+
+
+# ---------------------------------------------------------------------------
+# 1. Deployed versions (clamav-deploy values, private GitLab)
+# ---------------------------------------------------------------------------
+def _gitlab_headers() -> dict:
+    token = os.environ.get("GITLAB_TOKEN")
+    if not token:
+        raise SystemExit(
+            "GITLAB_TOKEN is required to read clamav-deploy values from GitLab."
+        )
+    return {"PRIVATE-TOKEN": token}
+
+
+def list_values_files() -> list[str]:
+    """List the per-environment values files under clamav-deploy `values/`."""
+    project = quote(CLAMAV_DEPLOY_PROJECT, safe="")
+    resp = requests.get(
+        f"{GITLAB_API}/projects/{project}/repository/tree",
+        headers=_gitlab_headers(),
+        params={"path": VALUES_PATH, "ref": DEPLOY_REF, "per_page": 100},
+        timeout=HTTP_TIMEOUT,
+    )
+    resp.raise_for_status()
+    return [
+        entry["path"]
+        for entry in resp.json()
+        if entry.get("type") == "blob" and entry["name"].endswith((".yaml", ".yml"))
+    ]
+
+
+def fetch_gitlab_file(path: str) -> str:
+    """Fetch one file's raw content from clamav-deploy via the GitLab API."""
+    project = quote(CLAMAV_DEPLOY_PROJECT, safe="")
+    resp = requests.get(
+        f"{GITLAB_API}/projects/{project}/repository/files/{quote(path, safe='')}/raw",
+        headers=_gitlab_headers(),
+        params={"ref": DEPLOY_REF},
+        timeout=HTTP_TIMEOUT,
+    )
+    resp.raise_for_status()
+    return resp.text
+
+
+def deployed_versions_from_values(values_files: dict[str, str]) -> dict:
     """
-    Retrieves the latest alpine version with a ClamAV
-    community package
+    Reduce raw {env_name: yaml_text} into deployed tag facts.
+
+    Returns {per_env, tags, reference_tag, drift}. `reference_tag` is the lowest
+    (most-behind) tag across all environments/components - the worst case for
+    ClamAV currency / EOL. `drift` is True when the tags are not all identical.
     """
+    per_env: dict[str, dict[str, str]] = {}
+    all_tags: list[str] = []
+    for env, text in values_files.items():
+        data = yaml.safe_load(text) or {}
+        comps = {}
+        for key in VERSION_KEYS:
+            section = data.get(key)
+            if isinstance(section, dict) and section.get("version"):
+                comps[key] = str(section["version"])
+        if comps:
+            per_env[env] = comps
+            all_tags.extend(comps.values())
+
+    if not all_tags:
+        raise SystemExit(
+            f"No {VERSION_KEYS} versions found in "
+            f"{CLAMAV_DEPLOY_PROJECT}/{VALUES_PATH}"
+        )
+
+    return {
+        "per_env": per_env,
+        "tags": all_tags,
+        "reference_tag": min(all_tags, key=version_key),
+        "drift": len(set(all_tags)) > 1,
+    }
 
 
-def get_latest_lts_version() -> float:
+def collect_deployed_versions() -> dict:
+    """Fetch clamav-deploy values and reduce them to deployed tag facts."""
+    values_files = {
+        Path(path).stem: fetch_gitlab_file(path) for path in list_values_files()
+    }
+    return deployed_versions_from_values(values_files)
+
+
+# ---------------------------------------------------------------------------
+# 2. Shipped pins (clamav-http Dockerfiles, at the deployed tag)
+# ---------------------------------------------------------------------------
+def parse_dockerfile(text: str, label: str) -> dict:
     """
-    Filters ClamAV versions to return the most-recent
-    LTS version (1.4.X)
+    Parse the ClamAV + Alpine versions pinned in a Dockerfile's text.
+
+    Handles both `FROM alpine:3.23.4` and `FROM python:3.14-alpine3.23`, and
+    `ENV CLAM_VERSION=1.4.4-r0` (or space-separated). `clamav` is None when the
+    file does not pin CLAM_VERSION.
     """
-    pass
+    clam = re.search(r"CLAM_VERSION[=\s]+([0-9][^\s\\]*)", text)
+    alpine = re.search(r"alpine:?(\d+\.\d+(?:\.\d+)?)", text)
+    return {
+        "path": label,
+        "clamav": clam.group(1) if clam else None,
+        "alpine": alpine.group(1) if alpine else None,
+        "alpine_branch": ".".join(alpine.group(1).split(".")[:2]) if alpine else None,
+    }
 
 
-def clam_av_update_required(current_clam_av_ver, latest_clam_av_ver) -> bool:
+def fetch_dockerfile_at_tag(tag: str, path: str) -> str:
+    """Fetch one clamav-http Dockerfile at a given tag (public GitHub raw)."""
+    resp = requests.get(
+        f"{CLAMAV_HTTP_RAW}/{normalize_tag(tag)}/{path}", timeout=HTTP_TIMEOUT
+    )
+    resp.raise_for_status()
+    return resp.text
+
+
+def collect_shipped_versions() -> dict:
     """
-    Compares the latest ClamAV LTS version against
-    the current version"""
-    pass
+    Resolve the deployed tag to the ClamAV / Alpine pins it actually ships.
 
-
-def alpine_update_required(current_alpine_ver, latest_alpine_ver) -> bool:
+    Reads the deployed tag from clamav-deploy, then parses both clamav-http
+    Dockerfiles at that tag. Returns the canonical shipped clamav / alpine_branch
+    plus a `drift` flag covering both deploy drift (envs/components disagree) and
+    Dockerfile drift (the two Dockerfiles disagree).
     """
-    Compares the latest Alpine version against
-    the current version"""
-    pass
+    deployed = collect_deployed_versions()
+    tag = deployed["reference_tag"]
+
+    per_file = []
+    for dockerfile in CLAMAV_DOCKERFILES:
+        text = fetch_dockerfile_at_tag(tag, dockerfile)
+        per_file.append(parse_dockerfile(text, f"{dockerfile}@{normalize_tag(tag)}"))
+
+    clam_versions = {f["clamav"] for f in per_file if f["clamav"]}
+    branch_versions = {f["alpine_branch"] for f in per_file if f["alpine_branch"]}
+
+    return {
+        "clamav": next(iter(clam_versions), None),
+        "alpine_branch": next(iter(branch_versions), None),
+        "per_file": per_file,
+        "reference_tag": tag,
+        "deployed": deployed,
+        "drift": deployed["drift"]
+        or len(clam_versions) > 1
+        or len(branch_versions) > 1,
+    }
 
 
-def build_title(latest_clam_av_ver) -> str:
+# ---------------------------------------------------------------------------
+# 3. Alpine-reachable versions (APKINDEX on the CDN)
+# ---------------------------------------------------------------------------
+def alpine_pkg_version(branch: str, pkg: str = "clamav") -> str | None:
     """
-    Builds the Jira ticket title from version"""
-    pass
+    Look up the version of `pkg` Alpine packages for a given branch.
 
-
-def ticket_already_exists(ticket_title: str) -> bool:
+    `branch` is an Alpine branch tag, e.g. "v3.23" or "edge". Downloads and
+    parses the community APKINDEX; returns None if the branch/package is absent.
     """
-    Checks if a ticket already exist for this upgrade
+    url = f"{ALPINE_CDN}/{branch}/{ALPINE_REPO}/{ALPINE_ARCH}/APKINDEX.tar.gz"
+    resp = requests.get(url, timeout=HTTP_TIMEOUT)
+    if resp.status_code == 404:
+        return None
+    resp.raise_for_status()
+
+    with tarfile.open(fileobj=io.BytesIO(resp.content), mode="r:gz") as tar:
+        member = tar.extractfile("APKINDEX")
+        index = member.read().decode() if member else ""
+
+    for block in index.split("\n\n"):
+        fields = dict(
+            line.split(":", 1) for line in block.splitlines() if ":" in line
+        )
+        if fields.get("P") == pkg:
+            return fields.get("V")
+    return None
+
+
+def reachable_clamav_versions(current_branch: str, alpine_data: list[dict]) -> dict:
     """
-    pass
+    Map each relevant Alpine branch to the clamav version it offers.
 
-
-def build_description(current_clam_av_ver, latest_clam_av_ver) -> str:
+    Covers our current branch, every *newer* stable branch, and edge - the set
+    the R1/R2/R3 rules reason over. Keys are "3.23"/"3.24"/"edge".
     """
-    Builds the Jira ticket description indicating the upgrade required
+    cur_key = version_key(current_branch)
+    branches = {current_branch}
+    for cycle in (c.get("cycle") for c in alpine_data):
+        if cycle and version_key(cycle) > cur_key:
+            branches.add(cycle)
+
+    reachable = {}
+    for branch in branches:
+        reachable[branch] = alpine_pkg_version(f"v{branch}")
+    reachable["edge"] = alpine_pkg_version("edge")
+    return {b: v for b, v in reachable.items() if v}
+
+
+# ---------------------------------------------------------------------------
+# 4. Upstream release + EOL data (endoflife.date)
+# ---------------------------------------------------------------------------
+def retrieve_clamav_data() -> list[dict]:
+    """Return endoflife.date's ClamAV cycles (latest release + eol per series)."""
+    resp = requests.get(CLAMAV_EOL_API, timeout=HTTP_TIMEOUT)
+    resp.raise_for_status()
+    return resp.json()
+
+
+def retrieve_alpine_data() -> list[dict]:
+    """Return endoflife.date's Alpine cycles (latest release + eol per branch)."""
+    resp = requests.get(ALPINE_EOL_API, timeout=HTTP_TIMEOUT)
+    resp.raise_for_status()
+    return resp.json()
+
+
+def find_cycle(data: list[dict], cycle: str) -> dict | None:
+    """Return the endoflife.date entry whose `cycle` matches, else None."""
+    return next((c for c in data if str(c.get("cycle")) == cycle), None)
+
+
+def upstream_latest(clamav_data: list[dict]) -> str | None:
+    """The newest ClamAV release across all series (e.g. "1.5.3")."""
+    latests = [c.get("latest") for c in clamav_data if c.get("latest")]
+    return max(latests, key=version_key) if latests else None
+
+
+# ---------------------------------------------------------------------------
+# Decision logic  (R1, R2, R4, R5 -> tickets; R3 -> signal)
+# ---------------------------------------------------------------------------
+def clam_av_update_required(current: str, reachable_in_branch: str) -> bool:
+    """R1 test: does our own Alpine branch already offer clamav > shipped?"""
+    return version_key(reachable_in_branch) > version_key(current)
+
+
+def alpine_update_required(current_branch_max: str, newer_branch_version: str) -> bool:
+    """R2 test: does a newer stable branch offer clamav we can't get in-branch?"""
+    return version_key(newer_branch_version) > version_key(current_branch_max)
+
+
+def evaluate(shipped: dict, reachable: dict, clamav_data: list[dict],
+             alpine_data: list[dict], warn_days: int = WARN_DAYS) -> list[dict]:
     """
+    Apply the decision rules and return a list of findings.
+
+    Each finding is a dict: {rule, actionable, priority, label, title, description}.
+    `actionable=True` findings become Jira tickets; `actionable=False` (R3) are
+    logged as a signal only.
+    """
+    findings: list[dict] = []
+    shipped_clam = shipped["clamav"]
+    branch = shipped["alpine_branch"]
+    cur_max = reachable.get(branch)
+
+    # R1 - in-branch bump (low risk: just repin CLAM_VERSION)
+    if cur_max and clam_av_update_required(shipped_clam, cur_max):
+        findings.append({
+            "rule": "R1",
+            "actionable": True,
+            "priority": "Medium",
+            "label": DEDUP_LABEL,
+            "title": f"Bump ClamAV to {cur_max} in clamav Dockerfiles",
+            "description": (
+                f"Alpine {branch} now packages clamav {cur_max}, ahead of the "
+                f"deployed {shipped_clam}.\n\nRepin CLAM_VERSION in: "
+                + ", ".join(f["path"] for f in shipped["per_file"]) + "."
+            ),
+        })
+
+    # R2 - base bump to reach a newer clamav a newer stable branch offers
+    stable_newer = {
+        b: v for b, v in reachable.items()
+        if b != "edge" and version_key(b) > version_key(branch)
+    }
+    if stable_newer:
+        best_branch = max(stable_newer, key=lambda b: version_key(stable_newer[b]))
+        best_ver = stable_newer[best_branch]
+        if cur_max and alpine_update_required(cur_max, best_ver):
+            findings.append({
+                "rule": "R2",
+                "actionable": True,
+                "priority": "Low",
+                "label": DEDUP_LABEL,
+                "title": f"Bump Alpine base {branch} -> {best_branch} to reach ClamAV {best_ver}",
+                "description": (
+                    f"Alpine {branch} is capped at clamav {cur_max}; branch "
+                    f"{best_branch} offers {best_ver}. Reaching it needs an "
+                    f"Alpine base bump ({branch} -> {best_branch}), a larger change "
+                    f"than an in-branch repin."
+                ),
+            })
+
+    # R4 - shipped ClamAV series approaching EOL
+    clam_cycle = find_cycle(clamav_data, series_of(shipped_clam))
+    if clam_cycle:
+        d = days_until(clam_cycle.get("eol"))
+        if d is not None and d <= warn_days:
+            findings.append({
+                "rule": "R4",
+                "actionable": True,
+                "priority": "High",
+                "label": DEDUP_LABEL,
+                "title": f"ClamAV {clam_cycle['cycle']} reaches EOL on {clam_cycle['eol']}",
+                "description": (
+                    f"Deployed ClamAV series {clam_cycle['cycle']} "
+                    f"{'is already past EOL' if d < 0 else f'reaches EOL in {d} days'} "
+                    f"({clam_cycle['eol']}). An EOL ClamAV eventually loses "
+                    f"virus-definition updates - plan an upgrade."
+                ),
+            })
+
+    # R5 - Alpine base branch approaching EOL
+    alpine_cycle = find_cycle(alpine_data, branch)
+    if alpine_cycle:
+        d = days_until(alpine_cycle.get("eol"))
+        if d is not None and d <= warn_days:
+            findings.append({
+                "rule": "R5",
+                "actionable": True,
+                "priority": "High",
+                "label": DEDUP_LABEL,
+                "title": f"Alpine {branch} base reaches EOL on {alpine_cycle['eol']}",
+                "description": (
+                    f"The Alpine {branch} base "
+                    f"{'is already past EOL' if d < 0 else f'reaches EOL in {d} days'} "
+                    f"({alpine_cycle['eol']}). Plan a base image bump."
+                ),
+            })
+
+    # R3 - upstream ahead of Alpine: signal only, never a ticket
+    up = upstream_latest(clamav_data)
+    best_reachable = max(reachable.values(), key=version_key) if reachable else None
+    if up and best_reachable and version_key(up) > version_key(best_reachable):
+        findings.append({
+            "rule": "R3",
+            "actionable": False,
+            "priority": None,
+            "label": None,
+            "title": f"ClamAV {up} released upstream; not yet in Alpine",
+            "description": (
+                f"Upstream ClamAV {up} is ahead of the best Alpine-reachable "
+                f"{best_reachable}. Nothing to action until Alpine packages it - "
+                f"R1/R2 will fire when it does."
+            ),
+        })
+
+    return findings
 
 
-def build_fields(image: dict) -> dict:
+# ---------------------------------------------------------------------------
+# Jira
+# ---------------------------------------------------------------------------
+def build_title(finding: dict) -> str:
+    return finding["title"]
+
+
+def build_description(finding: dict) -> str:
+    return finding["description"]
+
+
+def build_fields(finding: dict) -> dict:
     return {
         "project": {"key": JIRA_PROJECT},
-        "summary": build_title(image),
-        "description": build_description(image),
+        "summary": build_title(finding),
+        "description": build_description(finding),
         "issuetype": {"name": "Task"},
-        "priority": {"name": image["priority"]},
+        "priority": {"name": finding["priority"]},
+        "labels": [finding["label"]],
         JIRA_EPIC_FIELD: JIRA_EPIC_KEY,
     }
 
 
-def print_dry_run(image: dict) -> None:
-    fields = build_fields(image)
-    print("=" * 70)
-    print(f"SUMMARY:     {fields['summary']}")
-    print(f"PROJECT:     {JIRA_PROJECT}")
-    print(f"TYPE:        Task")
-    print(f"PRIORITY:    {image['priority']}")
-    print(f"EPIC:        {JIRA_EPIC_KEY}")
-    print(f"TAGS:        {len(image['affected_tags'])} affected")
-    print(f"REPOS:       {len(image['all_repos'])} repos")
-    latest = image.get("latest_tag")
-    if latest:
-        print(f"LATEST TAG:  :{latest['tag']} — {latest['critical']} critical, {latest['high']} high")
-    print()
-    print("--- DESCRIPTION ---")
-    print(fields["description"])
-    print("=" * 70)
+def open_ticket_titles(jira) -> set[str]:
+    """Summaries of our own open, label-tagged tickets (for de-dup)."""
+    jql = (
+        f'project = {JIRA_PROJECT} AND labels = "{DEDUP_LABEL}" '
+        f"AND statusCategory != Done"
+    )
+    issues = jira.jql(jql, fields="summary").get("issues", [])
+    return {i["fields"]["summary"] for i in issues}
 
 
-def create_ticket(jira: Jira, image: dict) -> str:
-    fields = build_fields(image)
-    result = jira.create_issue(fields=fields)
+def ticket_already_exists(title: str, existing_titles: set[str]) -> bool:
+    return title in existing_titles
+
+
+def create_ticket(jira, finding: dict) -> str:
+    result = jira.create_issue(fields=build_fields(finding))
     return result.get("key", str(result))
 
 
+def print_finding(finding: dict) -> None:
+    kind = "TICKET" if finding["actionable"] else "SIGNAL"
+    print("=" * 70)
+    print(f"[{finding['rule']}] {kind}"
+          + (f" (priority {finding['priority']})" if finding["priority"] else ""))
+    print(f"SUMMARY: {finding['title']}")
+    print("--- DESCRIPTION ---")
+    print(finding["description"])
+    print("=" * 70)
 
+
+# ---------------------------------------------------------------------------
+# Orchestration
+# ---------------------------------------------------------------------------
+def gather() -> tuple[dict, dict, list[dict], list[dict]]:
+    """Collect everything the rules need: shipped, reachable, upstream, alpine."""
+    shipped = collect_shipped_versions()
+    if not shipped["clamav"] or not shipped["alpine_branch"]:
+        raise SystemExit(
+            f"Could not parse ClamAV/Alpine from tag {shipped['reference_tag']}: "
+            f"{shipped['per_file']}"
+        )
+    clamav_data = retrieve_clamav_data()
+    alpine_data = retrieve_alpine_data()
+    reachable = reachable_clamav_versions(shipped["alpine_branch"], alpine_data)
+    return shipped, reachable, clamav_data, alpine_data
 
 
 def main() -> None:
-    parser = argparse.ArgumentParser(description="Create Jira tickets for vulnerable ACP images")
-    parser.add_argument("--dry-run", action="store_true", help="Print ticket fields without creating")
-    parser.add_argument("--all", action="store_true", help="Create tickets for all vulnerable base images")
-    parser.add_argument("--image", default=None, help="Target a specific base image (e.g. acp/dind)")
-    parser.add_argument("--auto", action="store_true",
-                        help="CI mode: process every eligible image and persist de-dup state")
-    parser.add_argument("--state-file", default=None,
-                        help="Path or s3:// URL holding the {short_base: jira_key} de-dup map")
+    parser = argparse.ArgumentParser(description="ClamAV version checker (ACPENG-2944)")
+    parser.add_argument("--dry-run", action="store_true",
+                        help="Print findings without touching Jira")
+    parser.add_argument("--warn-days", type=int, default=WARN_DAYS,
+                        help=f"Days before EOL to raise a ticket (default {WARN_DAYS})")
     args = parser.parse_args()
 
-    images, skipped = load_and_group(args.image)
+    if not os.environ.get("GITLAB_TOKEN"):
+        print("Error: GITLAB_TOKEN is not set (needed to read clamav-deploy values).")
+        sys.exit(1)
 
-    if not images and not skipped:
-        print("No vulnerable images found matching criteria.")
-        sys.exit(0)
+    shipped, reachable, clamav_data, alpine_data = gather()
 
-    if not images:
-        print("No images to process — all were skipped (see below).\n")
+    deployed = shipped["deployed"]
+    print("Deployed (from clamav-deploy values):")
+    for env, comps in deployed["per_env"].items():
+        print(f"  {env}: " + ", ".join(f"{k}={v}" for k, v in comps.items()))
+    print(f"Reference tag (lowest): {shipped['reference_tag']}"
+          + ("  [DRIFT across envs/components!]" if deployed["drift"] else ""))
+    print(f"Shipped:   clamav {shipped['clamav']} on alpine {shipped['alpine_branch']}")
+    print(f"Reachable: {reachable}")
+    print(f"Upstream:  {upstream_latest(clamav_data)}\n")
 
-    state: dict = {}
-    state_label = None
-    if args.state_file:
-        state, state_label = _load_state(args.state_file)
-        before = len(images)
-        images = [img for img in images if img["short_base"] not in state]
-        print(f"De-dup: {before - len(images)} image(s) already filed (state: {state_label}).")
+    findings = evaluate(shipped, reachable, clamav_data, alpine_data, args.warn_days)
+    tickets = [f for f in findings if f["actionable"]]
+    signals = [f for f in findings if not f["actionable"]]
 
-    if args.auto:
-        pass  # process everything that survived the de-dup filter
-    elif not args.all and not args.image:
-        images = images[:1]
+    for finding in signals:
+        print_finding(finding)
 
-    print(f"{'DRY RUN — ' if args.dry_run else ''}Processing {len(images)} base image(s)...\n")
+    if not tickets:
+        print("No actionable findings - nothing to file.")
+        return
 
     if args.dry_run:
-        for image in images:
-            print_dry_run(image)
-    elif images:
-        token = os.environ.get("JIRA_TOKEN")
-        if not token:
-            print("Error: JIRA_TOKEN environment variable is not set.")
-            sys.exit(1)
+        for finding in tickets:
+            print_finding(finding)
+        print(f"\nDRY RUN - would file {len(tickets)} ticket(s).")
+        return
 
-        jira = Jira(url=JIRA_URL, token=token)
+    token = os.environ.get("JIRA_TOKEN")
+    if not token:
+        print("Error: JIRA_TOKEN environment variable is not set.")
+        sys.exit(1)
 
-        for image in images:
-            try:
-                key = create_ticket(jira, image)
-            except Exception as e:
-                print(f"FAILED: {image['short_base']} — {e}")
-                continue
-            state[image["short_base"]] = key
-            print(f"Created: {key} — {image['short_base']} ({image['priority']})")
-            print(f"  {JIRA_URL}/browse/{key}")
+    from atlassian import Jira
+    jira = Jira(url=JIRA_URL, token=token)
+    existing = open_ticket_titles(jira)
 
-        if args.state_file:
-            _save_state(args.state_file, state)
-            print(f"\nState saved: {state_label} ({len(state)} entries)")
-
-    if skipped:
-        print(f"\n--- {len(skipped)} image(s) skipped (latest tag not found in latest_tags.json) ---")
-        for name in skipped:
-            print(f"  {name}")
+    for finding in tickets:
+        if ticket_already_exists(finding["title"], existing):
+            print(f"Skipped (already open): {finding['title']}")
+            continue
+        try:
+            key = create_ticket(jira, finding)
+        except Exception as exc:
+            print(f"FAILED [{finding['rule']}]: {exc}")
+            continue
+        print(f"Created {key} [{finding['rule']}]: {finding['title']}")
+        print(f"  {JIRA_URL}/browse/{key}")
 
 
 if __name__ == "__main__":

--- a/version-checker/version_checker.py
+++ b/version-checker/version_checker.py
@@ -602,7 +602,9 @@ def main() -> None:
         print(f"\nDRY RUN - would file {len(tickets)} ticket(s).")
         return
 
-    token = os.environ.get("JIRA_API_TOKEN")
+    # Strip: a stray newline or space from however the secret was stored makes
+    # the Bearer header malformed, and Jira answers as if we were anonymous.
+    token = os.environ.get("JIRA_API_TOKEN", "").strip()
     if not token:
         print("Error: JIRA_API_TOKEN environment variable is not set.")
         sys.exit(1)

--- a/version-checker/version_checker.py
+++ b/version-checker/version_checker.py
@@ -39,7 +39,7 @@ Usage:
 
 Requires:
     export GITLAB_TOKEN="read-only-PAT"      # always (reads clamav-deploy)
-    export JIRA_TOKEN="your-PAT"             # only when creating tickets
+    export JIRA_API_TOKEN="your-PAT"         # only when creating tickets
 """
 from __future__ import annotations
 
@@ -602,9 +602,9 @@ def main() -> None:
         print(f"\nDRY RUN - would file {len(tickets)} ticket(s).")
         return
 
-    token = os.environ.get("JIRA_TOKEN")
+    token = os.environ.get("JIRA_API_TOKEN")
     if not token:
-        print("Error: JIRA_TOKEN environment variable is not set.")
+        print("Error: JIRA_API_TOKEN environment variable is not set.")
         sys.exit(1)
 
     from atlassian import Jira

--- a/version-checker/version_checker.py
+++ b/version-checker/version_checker.py
@@ -35,13 +35,27 @@ JIRA_EPIC_KEY = "ACPENG-2598"
 WORKSPACE = Path(__file__).parent.parent / "workspace"
 
 
+def get_current_versions(dockerfile_path):
+    """
+    Reads the Dockerfile to get the current versions
+    of Alpine and ClamAV
+    """
+    pass
 
-def retrieve_latest_versions() -> list[str]:
+
+def retrieve_latest_clam_av_versions() -> list[str]:
     """
     Calls https://api.github.com/repos/Cisco-Talos/clamav/releases?per_page=5
     to get the latest 5 ClamAV releases 
     """
     pass
+
+
+def retrieve_latest_alpine_version():
+    """
+    Retrieves the latest alpine version with a ClamAV
+    community package
+    """
 
 
 def get_latest_lts_version() -> float:
@@ -51,9 +65,17 @@ def get_latest_lts_version() -> float:
     """
     pass
 
-def update_required(current_clam_av_ver, latest_clam_av_ver) -> bool:
+
+def clam_av_update_required(current_clam_av_ver, latest_clam_av_ver) -> bool:
     """
     Compares the latest ClamAV LTS version against
+    the current version"""
+    pass
+
+
+def alpine_update_required(current_alpine_ver, latest_alpine_ver) -> bool:
+    """
+    Compares the latest Alpine version against
     the current version"""
     pass
 
@@ -62,6 +84,7 @@ def build_title(latest_clam_av_ver) -> str:
     """
     Builds the Jira ticket title from version"""
     pass
+
 
 def ticket_already_exists(ticket_title: str) -> bool:
     """

--- a/version-checker/version_checker.py
+++ b/version-checker/version_checker.py
@@ -1,0 +1,185 @@
+#!/usr/bin/env python3
+"""
+Create Jira tickets for ACP ECR images with critical or high CVEs.
+
+Usage:
+    python3 scripts/create_vuln_tickets.py             # creates 1 ticket
+    python3 scripts/create_vuln_tickets.py --dry-run   # prints payload, no API call
+    python3 scripts/create_vuln_tickets.py --all       # creates all tickets
+    python3 scripts/create_vuln_tickets.py --image acp/dind  # specific base image
+    python3 scripts/create_vuln_tickets.py --auto      # CI mode: process all eligible
+                                                       # images, persist de-dup state
+    python3 scripts/create_vuln_tickets.py --auto --state-file s3://bucket/jira/created_tickets.json
+
+Requires:
+    export JIRA_TOKEN="your-PAT"
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import sys
+from collections import defaultdict
+from pathlib import Path
+from urllib.parse import urlparse
+
+from atlassian import Jira
+
+JIRA_URL = "https://collaboration.homeoffice.gov.uk/jira"
+JIRA_PROJECT = "ACPENG"
+JIRA_EPIC_FIELD = "customfield_10006"
+JIRA_EPIC_KEY = "ACPENG-2598"
+
+
+WORKSPACE = Path(__file__).parent.parent / "workspace"
+
+
+
+def retrieve_latest_versions() -> list[str]:
+    """
+    Calls https://api.github.com/repos/Cisco-Talos/clamav/releases?per_page=5
+    to get the latest 5 ClamAV releases 
+    """
+    pass
+
+
+def get_latest_lts_version() -> float:
+    """
+    Filters ClamAV versions to return the most-recent
+    LTS version (1.4.X)
+    """
+    pass
+
+def update_required(current_clam_av_ver, latest_clam_av_ver) -> bool:
+    """
+    Compares the latest ClamAV LTS version against
+    the current version"""
+    pass
+
+
+def build_title(latest_clam_av_ver) -> str:
+    """
+    Builds the Jira ticket title from version"""
+    pass
+
+def ticket_already_exists(ticket_title: str) -> bool:
+    """
+    Checks if a ticket already exist for this upgrade
+    """
+    pass
+
+
+def build_description(current_clam_av_ver, latest_clam_av_ver) -> str:
+    """
+    Builds the Jira ticket description indicating the upgrade required
+    """
+
+
+def build_fields(image: dict) -> dict:
+    return {
+        "project": {"key": JIRA_PROJECT},
+        "summary": build_title(image),
+        "description": build_description(image),
+        "issuetype": {"name": "Task"},
+        "priority": {"name": image["priority"]},
+        JIRA_EPIC_FIELD: JIRA_EPIC_KEY,
+    }
+
+
+def print_dry_run(image: dict) -> None:
+    fields = build_fields(image)
+    print("=" * 70)
+    print(f"SUMMARY:     {fields['summary']}")
+    print(f"PROJECT:     {JIRA_PROJECT}")
+    print(f"TYPE:        Task")
+    print(f"PRIORITY:    {image['priority']}")
+    print(f"EPIC:        {JIRA_EPIC_KEY}")
+    print(f"TAGS:        {len(image['affected_tags'])} affected")
+    print(f"REPOS:       {len(image['all_repos'])} repos")
+    latest = image.get("latest_tag")
+    if latest:
+        print(f"LATEST TAG:  :{latest['tag']} — {latest['critical']} critical, {latest['high']} high")
+    print()
+    print("--- DESCRIPTION ---")
+    print(fields["description"])
+    print("=" * 70)
+
+
+def create_ticket(jira: Jira, image: dict) -> str:
+    fields = build_fields(image)
+    result = jira.create_issue(fields=fields)
+    return result.get("key", str(result))
+
+
+
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Create Jira tickets for vulnerable ACP images")
+    parser.add_argument("--dry-run", action="store_true", help="Print ticket fields without creating")
+    parser.add_argument("--all", action="store_true", help="Create tickets for all vulnerable base images")
+    parser.add_argument("--image", default=None, help="Target a specific base image (e.g. acp/dind)")
+    parser.add_argument("--auto", action="store_true",
+                        help="CI mode: process every eligible image and persist de-dup state")
+    parser.add_argument("--state-file", default=None,
+                        help="Path or s3:// URL holding the {short_base: jira_key} de-dup map")
+    args = parser.parse_args()
+
+    images, skipped = load_and_group(args.image)
+
+    if not images and not skipped:
+        print("No vulnerable images found matching criteria.")
+        sys.exit(0)
+
+    if not images:
+        print("No images to process — all were skipped (see below).\n")
+
+    state: dict = {}
+    state_label = None
+    if args.state_file:
+        state, state_label = _load_state(args.state_file)
+        before = len(images)
+        images = [img for img in images if img["short_base"] not in state]
+        print(f"De-dup: {before - len(images)} image(s) already filed (state: {state_label}).")
+
+    if args.auto:
+        pass  # process everything that survived the de-dup filter
+    elif not args.all and not args.image:
+        images = images[:1]
+
+    print(f"{'DRY RUN — ' if args.dry_run else ''}Processing {len(images)} base image(s)...\n")
+
+    if args.dry_run:
+        for image in images:
+            print_dry_run(image)
+    elif images:
+        token = os.environ.get("JIRA_TOKEN")
+        if not token:
+            print("Error: JIRA_TOKEN environment variable is not set.")
+            sys.exit(1)
+
+        jira = Jira(url=JIRA_URL, token=token)
+
+        for image in images:
+            try:
+                key = create_ticket(jira, image)
+            except Exception as e:
+                print(f"FAILED: {image['short_base']} — {e}")
+                continue
+            state[image["short_base"]] = key
+            print(f"Created: {key} — {image['short_base']} ({image['priority']})")
+            print(f"  {JIRA_URL}/browse/{key}")
+
+        if args.state_file:
+            _save_state(args.state_file, state)
+            print(f"\nState saved: {state_label} ({len(state)} entries)")
+
+    if skipped:
+        print(f"\n--- {len(skipped)} image(s) skipped (latest tag not found in latest_tags.json) ---")
+        for name in skipped:
+            print(f"  {name}")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
https://collaboration.homeoffice.gov.uk/jira/browse/ACPENG-2944

Code reads the version from `clamav-deploy`'s `values/<env>.yaml` → resolve to that `clamav-http` tag → read the
ClamAV/Alpine pins from the Dockerfiles there → compare against what Alpine currently offers and what upstream has released. Where environments disagree it takes the **lowest** (most-behind) version and flags the drift.

| Rule | Condition | Outcome |
|------|-----------|---------|
| R1 | Newer ClamAV in the Alpine branch we're on | Ticket, **Medium** |
| R2 | Newer ClamAV only on a newer Alpine base | Ticket, **Low** |
| R4/R5 | ClamAV series / Alpine branch near EOL | Ticket, **High** |
| R3 | Upstream ahead of what Alpine packages | **Signal only — no ticket** |

R3 files nothing deliberately: there's no action available until Alpine packages the release. Re-filing is prevented by a JQL check for an open ticket with the same title.

## Changes

`version-checker/` (checker + 14 tests + requirements) and a new `version-check` pipeline in `.drone.yml` (`event: [cron]`, target master). The build/scan/push pipeline only changes to exclude the `cron` event, so this can't fire on a push.

## Testing

- **14 unit tests passing** — version comparison, Dockerfile parsing, the lowest-version + drift reduction, and every rule including R3's no-ticket case and the all-quiet negative.
- **Full local dry-run** against the real GitLab/GitHub/endoflife.date: resolved the  deployed tag, parsed the pins, produced the expected finding, filed nothing.

**Not testable until merged:** the Jira create path, and whether the `drone-gh` pods can reach internal GitLab. A cron build checks out *master's* `.drone.yml`, so both only become exercisable after merge. On merge: register the cron, run once, confirm the ticket.

## Secrets

`gitlab_token` (read-only `clamav-deploy` PAT) and `JIRA_API_TOKEN` (same one `acp-mend-renovate` uses) are already Drone repo secrets, with `Pull Request Read: false`.

The cron doesn't pass `--dry-run`, so the first firing files a real **Low** ticket (the R2 bump the dry-run surfaced). That's intentional — it's what proves the Jira path.

## Unrelated drive-by

`e424d2b` bumps the Go builder 1.26.4 → 1.26.5 in `clamav-http/Dockerfile` and `clamav-mirror/Dockerfile`. Trivy started failing the image scan on two Go stdlib CVEs (CVE-2026-39822 HIGH, CVE-2026-42505 MEDIUM) that are compiled into the binaries and fixed in 1.26.5. `master` is red for the same reason — this isn't introduced by the version-checker.

